### PR TITLE
PDF::Builder support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,17 @@
 Revision history for CtrlO::PDF
 
-0.07 Sat Dec 12 2020  UNRELEASED
+0.08 Wed Jan 06 2021  UNRELEASED
+
+    * remove PDF::API2 as a prerequisite, allowing PDF::Builder to be used
+      (and if absent, look for PDF::API2). The PDFlib option can be used to
+      specify either PDF::API2 or PDF::Builder (the default) as your PDF
+      support library.
+    * PDF::API2 removed as an installation prerequisite (either PDF::API2 or
+      PDF::Builder is needed to run). If neither is installed, Makefile.PL 
+      will install PDF::Builder (easily configured which).
+    * use README.md instead of README, to get formatting
+
+0.07 Tue Dec 22 2020
 
     * minor corrections and cleanup to make POD and README consistent
     * make example (POD, README) fully working, save out.pdf file

--- a/MANIFEST
+++ b/MANIFEST
@@ -6,7 +6,7 @@ Makefile.PL
 MANIFEST			This list of files
 META.json
 META.yml
-README
+README.md
 sample/ctrlo.pl
 sample/logo.png
 t/001_base.t

--- a/META.json
+++ b/META.json
@@ -39,7 +39,7 @@
             "Image::Info" : "0",
             "Moo" : "0",
             "MooX::Types::MooseLike::Base" : "0",
-            "PDF::API2" : "0",
+           #"PDF::API2" : "0",
             "PDF::Table" : "0",
             "PDF::TextBlock" : "0"
          }
@@ -55,7 +55,7 @@
          "url" : "https://github.com/ctrlo/CtrlO-PDF"
       }
    },
-   "version" : "0.07",
+   "version" : "0.08",
    "x_serialization_backend" : "JSON::PP version 2.27400_02"
 }
 

--- a/META.yml
+++ b/META.yml
@@ -25,12 +25,11 @@ requires:
   Image::Info: '0'
   Moo: '0'
   MooX::Types::MooseLike::Base: '0'
-  PDF::API2: '0'
   PDF::Table: '0'
   PDF::TextBlock: '0'
 resources:
   bugtracker: https://github.com/ctrlo/CtrlO-PDF/issues
   homepage: https://github.com/ctrlo/CtrlO-PDF/
   repository: https://github.com/ctrlo/CtrlO-PDF
-version: '0.07'
+version: '0.08'
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,14 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker;
 
-WriteMakefile(
+my $choice = 'Builder';  # API2 or Builder default prerequisite?
+my $debug = 0;  # 1 to just dump contents
+my %versions = (  # minimum version for either
+    'API2'    => 2.038,
+    'Builder' => 3.021,
+);
+
+my %WriteMakefileArgs = (
     NAME                => 'CtrlO::PDF',
     AUTHOR              => q{Andy Beverley <andy@andybev.com>},
     VERSION_FROM        => 'lib/CtrlO/PDF.pm',
@@ -21,7 +28,6 @@ WriteMakefile(
         'Image::Info' => 0,
         'Moo' => 0,
         'MooX::Types::MooseLike::Base' => 0,
-        'PDF::API2' => 0,
         'PDF::Table' => 0,
         'PDF::TextBlock' => 0,
     },
@@ -36,3 +42,38 @@ WriteMakefile(
     },
 
 );
+
+# if neither PDF::API2 nor PDF::Builder is installed, prereq one of them
+my $rc;
+$rc = eval {
+    require PDF::API2;
+    1;
+};
+if (!defined $rc) { $rc = 0; }
+if ($rc) {
+    # PDF::API2 installed but not up to date?
+    if ($PDF::API2::VERSION < $versions{'API2'}) { $rc = 0; }
+}
+if (!$rc) {
+    # no PDF::API2. try PDF::Builder.
+    $rc = eval {
+        require PDF::Builder;
+        1;
+    };
+    if (!defined $rc) { $rc = 0; }
+    if ($rc) {
+        # PDF::Builder installed but not up to date?
+        if ($PDF::Builder::VERSION < $versions{'Builder'}) { $rc = 0; }
+    }
+}
+# suitable level of PDF::* not already installed?
+if (!$rc) {
+    $WriteMakefileArgs{'PREREQ_PM'}{"PDF::$choice"} = $versions{$choice};
+}
+
+if ($debug) {
+    use Data::Dumper;  # two lines for checking prereq work
+    print Dumper(\%WriteMakefileArgs);
+} else {
+    WriteMakefile(%WriteMakefileArgs);
+}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ CtrlO::PDF - high level PDF creator
         logo        => "sample/logo.png", # optional
         orientation => "portrait", # Default
         footer      => "My PDF document footer",
+        PDFlib      => "Builder",  # Default
     );
 
     # Add a page
@@ -61,15 +62,15 @@ pagination, headings, paragraph text, images and tables. Although there are a
 number of other modules to create PDFs with a high-level interface, I found
 that these each lack certain features (e.g. image insertion, paragraph text).
 This module tries to include each of those features through another existing
-module. Also, it is built on PDF::API2, and provides access to that object, so
-content can also be added directly using that, thereby providing any powerful
-features required.
+module. Also, it is built on your choice of PDF::Builder or PDF::API2, and 
+provides access to that object, so content can also be added directly using 
+that, thereby providing any powerful features required.
 
 # METHODS
 
 ## pdf
 
-Returns the `PDF::API2` object used to create the PDF.
+Returns the `PDF::Builder` or `PDF::API2` object used to create the PDF.
 
 ## page
 
@@ -120,9 +121,10 @@ Sets or returns the footer text. Page numbers are added automatically.
 
 ## font
 
-Sets or returns the font. This is based on PDF::API2 ttfont which returns a
-TrueType or OpenType font object. By default it assumes the font is available
-in the exact path `truetype/liberation/LiberationSans-Regular.ttf`. A future
+Sets or returns the font. This is based on `PDF::Builder` or `PDF::API2` 
+ttfont, which returns a TrueType or OpenType font object. By default, it 
+assumes the font is available in the exact path 
+`truetype/liberation/LiberationSans-Regular.ttf`. A future
 version may make this more flexible.
 
 ## fontbold

--- a/lib/CtrlO/PDF.pm
+++ b/lib/CtrlO/PDF.pm
@@ -8,11 +8,10 @@ use Carp qw/croak/;
 use Image::Info qw(image_info image_type);
 use Moo;
 use MooX::Types::MooseLike::Base qw(:all);
-use PDF::API2;
 use PDF::Table;
 use PDF::TextBlock;
 
-our $VERSION = '0.07';
+our $VERSION = '0.08';
 
 =head1 NAME 
 
@@ -24,10 +23,24 @@ CtrlO::PDF - high level PDF creator
   use Text::Lorem;
 
   my $pdf = CtrlO::PDF->new(
-      logo        => "sample/logo.png", # optional
-      orientation => "portrait", # Default
-      footer      => "My PDF document footer",
+      logo         => "sample/logo.png", # optional
+      logo_scaling => 0.5,               # Default
+      width        => 595,               # Default (A4, portrait mode)
+      height       => 842,               # Default (A4, portrait mode)
+      orientation  => "portrait",        # Default
+      margin       => 40,                # Default, all 4 sides
+      top_padding  => 0,                 # Default
+      header       => "My PDF document header",  # optional
+      footer       => "My PDF document footer",  # optional
+      PDFlib       => "API2",            # Default is Builder
   );
+  # width, height page dimensions in points (default A4 paper)
+  # orientation defaults to portrait (taller than wide)
+  # margin in points on all four sides
+  # top padding below header in points
+  # header, footer text line to place at top or bottom
+  # PDFlib actually checked only for '[aA]' or '[bB]', permitting a wide
+  #   range of formats to specify the PDF support library
 
   # Add a page
   $pdf->add_page;
@@ -77,9 +90,9 @@ pagination, headings, paragraph text, images and tables. Although there are a
 number of other modules to create PDFs with a high-level interface, I found
 that these each lack certain features (e.g. image insertion, paragraph text).
 This module tries to include each of those features through another existing
-module. Also, it is built on PDF::API2, and provides access to that object, so
-content can also be added directly using that, thereby providing any powerful
-features required.
+module. Also, it is built on either PDF::Builder or PDF::API2, and provides 
+access to that object, so content can also be added directly using that, 
+thereby providing any powerful features required.
 
 =head1 METHODS
 
@@ -87,7 +100,7 @@ features required.
 
 =head2 pdf
 
-Returns the C<PDF::API2> object used to create the PDF.
+Returns the C<PDF::Builder> or C<PDF::API2> object used to create the PDF.
 
 =cut
 
@@ -97,7 +110,55 @@ has pdf => (
 
 sub _build_pdf
 {   my $self = shift;
-    PDF::API2->new;
+
+    # what's available?
+    my ($rc);
+    if (lc($self->PDFlib) =~ m/b/) {
+        # PDF::Builder preferred, try to see if it's installed
+        $rc = eval {
+            require PDF::Builder;
+            1;
+        };
+        if (!defined $rc) {
+            # PDF::Builder not available, try PDF::API2
+            $rc = eval {
+                require PDF::API2;
+                1;
+            };
+            if (!defined $rc) {
+                die "Neither PDF::Builder nor PDF::API2 is installed!\n";
+            } else {
+ 	       #print "PDF::Builder requested, but was not available. Using PDF::API2\n";
+                PDF::API2->new;
+            }
+        } else {
+            PDF::Builder->new;
+        }
+ 
+    } else {
+        # PDF::API2 preferred, try to see if it's installed
+        $rc = eval {
+            require PDF::API2;
+            1;
+        };
+        if (!defined $rc) {
+            # PDF::API2 not available, try PDF::Builder
+            $rc = eval {
+                require PDF::Builder;
+                1;
+            };
+            if (!defined $rc) {
+                die "Neither PDF::API2 nor PDF::Builder is installed!\n";
+            } else {
+ 	       #print "PDF::API2 requested, but was not available. Using PDF::Builder\n";
+                PDF::Builder->new;
+            }
+        } else {
+            PDF::API2->new;
+        }
+ 
+    }
+ 
 }
 
 =head2 page
@@ -169,7 +230,8 @@ sub clear_new_page
 
 =head2 orientation
 
-Sets or returns the page orientation (portrait or landscape). Portrait is default.
+Sets or returns the page orientation (portrait or landscape). The default is
+Portrait (taller than wide).
 
 =cut
 
@@ -177,6 +239,21 @@ has orientation => (
     is      => 'ro',
     isa     => Str,
     default => 'portrait',
+);
+
+=head2 PDFlib
+
+Sets or returns the PDF-building library in use. The choices are "PDF::Builder" 
+and "PDF::API2" (case-insensitive). "PDF::Builder" is the default, indicating 
+that PDF::Builder will be used I<unless> it is not found, in which case 
+PDF::API2 will be used. If neither is found, CtrlO::PDF will fail.
+
+=cut
+
+has PDFlib => (
+    is      => 'ro',
+    isa     => Str,
+    default => 'PDF::Builder',
 );
 
 =head2 width
@@ -192,7 +269,7 @@ has width => (
 
 sub _build_width
 {   my $self = shift;
-    $self->orientation eq 'portrait' ? 595 : 842;
+    $self->orientation eq 'portrait' ? 595 : 842;  # A4 media
 }
 
 has _width_print => (
@@ -218,7 +295,7 @@ has height => (
 
 sub _build_height
 {   my $self = shift;
-    $self->orientation eq 'portrait' ? 842 : 595;
+    $self->orientation eq 'portrait' ? 842 : 595;  # A4 media
 }
 
 =head2 margin
@@ -267,9 +344,10 @@ has footer => (
 
 =head2 font
 
-Sets or returns the font. This is based on PDF::API2 ttfont which returns a
-TrueType or OpenType font object. By default it assumes the font is available
-in the exact path C<truetype/liberation/LiberationSans-Regular.ttf>. A future
+Sets or returns the font. This is based on PDF::Builder or PDF::API2 ttfont, 
+which returns a TrueType or OpenType font object. By default it assumes the 
+font is available in the exact path 
+C<truetype/liberation/LiberationSans-Regular.ttf>. A future
 version may make this more flexible.
 
 =cut
@@ -562,7 +640,11 @@ sub text
                 b => PDF::TextBlock::Font->new({
                     pdf  => $self->pdf,
                     font => $self->fontbold,
+		   #fillcolor => ??,   TBD
                 }),
+	        # TBD any way to specify the "normal" font? otherwise, 
+		# PDF::TextBlock opens up Helvetica corefont.
+		# see PDF::TextBlock::Font for possible solution
             },
         });
     }
@@ -600,8 +682,9 @@ sub table
         w         => $self->_width_print,
         font_size => 10,
         padding   => 5,
-        start_y   => $self->_y,
-        start_h   => $self->height - ($self->height - $self->_y) - $self->margin - $hf_space,
+	# start_y deprecated, change soon to y. start_h deprecated, change to h
+        y         => $self->_y,
+        h         => $self->height - ($self->height - $self->_y) - $self->margin - $hf_space,
         next_y    => $self->height - $self->margin - ($self->height - $self->_y_start_default),
     );
     my ($final_page, $number_of_pages, $final_y) = $table->table(
@@ -609,10 +692,10 @@ sub table
         $self->page,
         $data,
         %dimensions,
-        horizontal_borders => 2,
-        vertical_borders   => 0,
-        border_color => '#dddddd',
-        background_color_odd => '#f9f9f9',
+        h_border_w    => 2,
+        v_border_w    => 0,
+        border_c      => '#dddddd',
+        bg_color_odd  => '#f9f9f9',
         new_page_func => sub { $self->add_page },
         font          => $self->font,
         header_props => {
@@ -621,7 +704,7 @@ sub table
             justify    => 'left',
             font_size  => 10,
             bg_color   => 'white',
-            font_color => 'black',
+            fg_color   => 'black',
         },
         %options,
     );
@@ -713,7 +796,7 @@ sub content
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright 2018-2020 Ctrl O Ltd
+Copyright 2018-2021 Ctrl O Ltd
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of either: the GNU General Public License (GPL) as published by the 

--- a/sample/ctrlo.pl
+++ b/sample/ctrlo.pl
@@ -1,7 +1,5 @@
 use warnings;
 use strict;
-# not shipped as part of package
-# update synopsis to write out $file to "out.pdf"
 
 use CtrlO::PDF;
 use Text::Lorem;
@@ -10,6 +8,12 @@ my $pdf = CtrlO::PDF->new(
     logo        => "sample/logo.png",
     orientation => "portrait", # Default
     footer      => "My PDF document footer",
+    header      => "My PDF document header",
+    margin      => 50,
+    logo_padding=> 50,
+    top_padding => 60,
+    PDFlib      => 'builder',
+    # PDFlib default is Builder; use API2 if Builder not installed
 );
 
 # Add a page


### PR DESCRIPTION
Most of PDF::TextBlock has been updated, although Jay's build process forgot the new t-tests. Still, I'll go ahead and create a PR for CtrlO::PDF -- it's up to you whether you want to wait for PDF::TextBlock 0.13 (with the forgotten installation tests restored), or go ahead now. For someone with PDF::API2 _or_ PDF::Builder already installed, it should work fine. If PDF::TextBlock has to install one or the other (PDF::Builder by default), it currently won't test against PDF::Builder, but otherwise it should work fine.