### PR TITLE
Widow support for tables

### DIFF
--- a/lib/CtrlO/PDF.pm
+++ b/lib/CtrlO/PDF.pm
@@ -246,6 +246,18 @@ has PDFlib => (
     default => 'PDF::Builder',
 );
 
+=head2 font_size
+
+Sets or returns the font size. Default is 10 (points).
+
+=cut
+
+has font_size => (
+    is      => 'ro',
+    isa     => Int,
+    default => 10,
+);
+
 =head2 width
 
 Sets or returns the width. Default is A4.
@@ -660,7 +672,7 @@ sub text
 
     $string or return;
 
-    my $size = delete $options{size} || 10;
+    my $size = delete $options{size} || $self->font_size;
     my $color = delete $options{color} || 'black';
     my $format = delete $options{format} || 'none';
 
@@ -752,14 +764,14 @@ sub table
 
     # Create spacing above and below table based on the line spacing for text
     # of 10 points
-    $self->_down($self->_line_height(10));
+    $self->_down($self->_line_height($self->font_size));
 
     # Keep separate so easy to dump for debug
     my %dimensions = (
         next_h    => $self->_y_start_default - $self->margin_bottom,
         x         => $self->_x,
         w         => $self->_width_print,
-        font_size => 10,
+        font_size => $self->font_size,
         padding   => 5,
         y         => $self->_y,
         h         => $self->_y - $self->margin_bottom,
@@ -780,7 +792,7 @@ sub table
             font       => $self->fontbold,
             repeat     => 1,
             justify    => 'left',
-            font_size  => 10,
+            font_size  => $self->font_size,
             bg_color   => 'white',
             fg_color   => 'black',
         },
@@ -789,7 +801,7 @@ sub table
     $self->clear_new_page;
     $self->_set__y($final_y);
     # As above, padding below table
-    $self->_down($self->_line_height(10));
+    $self->_down($self->_line_height($self->font_size));
 }
 
 sub _image_type

--- a/lib/CtrlO/PDF.pm
+++ b/lib/CtrlO/PDF.pm
@@ -766,7 +766,6 @@ sub table
     # of 10 points
     $self->_down($self->_line_height($self->font_size));
 
-    # Keep separate so easy to dump for debug
     my %dimensions = (
         next_h    => $self->_y_start_default - $self->margin_bottom,
         x         => $self->_x,
@@ -777,10 +776,7 @@ sub table
         h         => $self->_y - $self->margin_bottom,
         next_y    => $self->_y_start_default,
     );
-    my ($final_page, $number_of_pages, $final_y) = $table->table(
-        $self->pdf,
-        $self->page,
-        $data,
+    %options = (
         %dimensions,
         h_border_w    => 2,
         v_border_w    => 0,
@@ -796,6 +792,12 @@ sub table
             bg_color   => 'white',
             fg_color   => 'black',
         },
+        %options,
+    );
+    my ($final_page, $number_of_pages, $final_y) = $table->table(
+        $self->pdf,
+        $self->page,
+        $data,
         %options,
     );
     $self->clear_new_page;

--- a/t/003_table.t
+++ b/t/003_table.t
@@ -43,15 +43,16 @@ sub test_page_boundary {
     is $pdf->pdf->page_count, 2, 'Our table spanned two pages';
 }
 
-# The table *header* can wrap over a page boundary as well.
+# The table *header* can wrap over a page boundary as well. Setting the Y position to just one
+# point higher results in the first two lines of the table fitting on the page.
 
 sub test_header_page_boundary {
     my $pdf = CtrlO::PDF->new(
         header => "Stuff at the top",
         footer => "Stuff at the bottom",
     );
-    $pdf->page;
-    $pdf->set_y_position(120);
+    $pdf->text('This page unintentionally left blank');
+    $pdf->set_y_position(169);
     # There isn't room on the page, with the standard font size, for all entries in Borges'
     # classification.
     $pdf->table(data => [
@@ -75,4 +76,9 @@ sub test_header_page_boundary {
         ]
     ]);
     is $pdf->pdf->page_count, 2, 'Our table spanned two pages';
+    if ($ENV{AUTHOR_TESTING}) {
+        open (my $fh, '>', 'header_page_boundary.pdf');
+        print $fh $pdf->content;
+        close $fh;
+    }
 }

--- a/t/003_table.t
+++ b/t/003_table.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use CtrlO::PDF;
+
+subtest 'Normal-sized table'                      => \&test_normality;
+subtest 'Table straddling a page boundary'        => \&test_page_boundary;
+done_testing();
+
+# We can produce a table without any weirdness.
+
+sub test_normality {
+    my $pdf = CtrlO::PDF->new;
+
+    ok $pdf->is_new_page, 'Nothing on the page yet';
+    my $starting_y_position = $pdf->y_position;
+    $pdf->table(data => [
+        ['Country', 'Capital City'],
+        ['France',  'Paris'],
+        ['Spain',   'Madrid'],
+        ['Andorra', 'Also Andorra lol'],
+    ]);
+    ok $pdf->y_position < $starting_y_position, 'We say we did something';
+}
+
+# A table can wrap over a page.
+
+sub test_page_boundary {
+    my $pdf = CtrlO::PDF->new(
+        header => 'Print this at the top',
+        footer => 'Print this at the bottom'
+    );
+    is $pdf->pdf->page_count, 0, 'No pages at all at first';
+    $pdf->table(data => [
+        ['Number', 'Fizzbuzz'],
+        map {
+            [$_ , ucfirst( ( $_ % 3 ? '' : 'fizz' ) . ( $_ % 5 ? '' : 'buzz' ) )],
+        } 1..40
+    ]);
+    is $pdf->pdf->page_count, 2, 'Our table spanned two pages';
+}

--- a/t/003_table.t
+++ b/t/003_table.t
@@ -7,6 +7,7 @@ use CtrlO::PDF;
 
 subtest 'Normal-sized table'                      => \&test_normality;
 subtest 'Table straddling a page boundary'        => \&test_page_boundary;
+subtest 'Table header straddling a page boundary' => \&test_header_page_boundary;
 done_testing();
 
 # We can produce a table without any weirdness.
@@ -38,6 +39,40 @@ sub test_page_boundary {
         map {
             [$_ , ucfirst( ( $_ % 3 ? '' : 'fizz' ) . ( $_ % 5 ? '' : 'buzz' ) )],
         } 1..40
+    ]);
+    is $pdf->pdf->page_count, 2, 'Our table spanned two pages';
+}
+
+# The table *header* can wrap over a page boundary as well.
+
+sub test_header_page_boundary {
+    my $pdf = CtrlO::PDF->new(
+        header => "Stuff at the top",
+        footer => "Stuff at the bottom",
+    );
+    $pdf->page;
+    $pdf->set_y_position(120);
+    # There isn't room on the page, with the standard font size, for all entries in Borges'
+    # classification.
+    $pdf->table(data => [
+        [
+            'Name', 'Belongs to the Emperor?',
+            'Embalmed / Trained / Suckling pig / Mermaid / Siren / Fabled / Stray dog?',
+            'Included in this classification?',
+            'Trembles as if they were mad?', 'Innumerable?',
+            'Drawn with a very fine camel hair brush?',
+            'etc.?',
+        ],
+        [
+            'Soldier', 'Some of them do', 'Trained, eventually fabled',
+            'No', 'Hard to tell',
+            'Rarely', 'No', 'etc.'
+        ],
+        [
+            'Chimera', 'No', 'Sort-of like a mermaid, fabled?',
+            'Which classification anyway?',
+            'Parts might', 'No', 'No', 'etc.'
+        ]
     ]);
     is $pdf->pdf->page_count, 2, 'Our table spanned two pages';
 }


### PR DESCRIPTION
This was a wish-list item already, but exacerbated by a [crashing bug in PDF::Table](https://github.com/PhilterPaper/PDF-Table/pull/81) if there isn't enough room to display a header row on the current page.