### PR TITLE
Add --verbose flag and install libpng-dev

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install libpng
+        run: |
+            apt install libpng-dev
+
       - name: Prepare for testing
         run: |
             cpanm --installdep --notest --verbose .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install libpng
         run: |
-            apt install libpng-dev
+            apt install -y libpng-dev
 
       - name: Prepare for testing
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Prepare for testing
         run: |
-            cpanm --installdep --notest .
+            cpanm --installdep --notest --verbose .
 
       - name: Release tests
         env:


### PR DESCRIPTION
Adding the --verbose flag to cpanm helped reveal that the failure in the installation in one of the dependencies was the lack of libpng-dev on the system.

This PR adds the `--verbose` flag and installs `libpng-dev`.

This helps us to see the test failure in the project. It will be addressed in a separate PR. 

