### PR TITLE
test case for duplicate call

### DIFF
--- a/t/002_basic.t
+++ b/t/002_basic.t
@@ -26,4 +26,8 @@ subtest baisc => sub {
     $pdf->text("Foobar");
 
     compare_pdf($pdf, '002_basic.pdf');
+    eval {
+        compare_pdf($pdf, '002_basic.pdf');
+    };
+    like $@, qr/Can't use an undefined value as an ARRAY reference/;
 };


### PR DESCRIPTION
This test case currently passes, but the 2nd call to `compare_pdf` should **not** raise an exception.
It does because of this error: #12
So once that issue is fixed we should be able to just call compare_pdf twice.

